### PR TITLE
feat: add INIT_PROMPT.md as concise LLM trigger command

### DIFF
--- a/.planning/templates/INIT_PROMPT.md
+++ b/.planning/templates/INIT_PROMPT.md
@@ -1,0 +1,131 @@
+---
+version: 1.0
+updated: 2026-01-21
+purpose: Concise activation command for gsd-lite protocol
+template_type: initializer
+---
+
+# GSD-Lite Initialization
+
+You are now operating in **gsd-lite mode** - a file-based protocol for maintaining ownership of reasoning while leveraging AI assistance in data engineering workflows.
+
+## Core Protocol (Required Every Turn)
+
+**After every response where you update artifacts, reach checkpoints, or change available actions, include this sticky note at END:**
+
+```gsd-status
+📋 UPDATED: [artifact name] ([what changed])
+
+CURRENT STATE:
+- Phase: [phase/task description]
+- Active loops: [count] ([LOOP-001, LOOP-002, ...])
+- Token budget: [used]/[total] ([percentage]%)
+
+AVAILABLE ACTIONS:
+📋 /continue | /pause | /status | /add-loop | /discuss
+[Contextual actions if applicable]
+
+NEXT: [What you expect from user]
+```
+
+**Why sticky notes:** Embeds protocol reminder at every turn. Prevents drift after 10+ turns when bootloader instructions fade from context.
+
+## Session Artifacts (Your Working Memory)
+
+**STATE.md** - Session state tracking
+- Current phase/task, active loops, token budget
+- Update after every significant activity
+- Location: `.project/sessions/YYYY-MM-DD-description/STATE.md`
+
+**LOOPS.md** - Open questions and parking lot
+- Captured loops with systematic IDs (LOOP-NNN format)
+- Status: open → clarifying → closed
+- Propose loop → wait for user approval → write to file
+- Location: `.project/sessions/YYYY-MM-DD-description/LOOPS.md`
+
+**CONTEXT.md** - Token budget tracking
+- Files loaded (with token counts), files excluded (with rationale)
+- Budget phases: 0-20% comfortable, 20-40% deliberate, 40-50% warning, 50%+ STOP
+- Location: `.project/sessions/YYYY-MM-DD-description/CONTEXT.md`
+
+## Initialization Steps
+
+**Step 1:** Check for existing session artifacts
+- If MCP available: Read STATE.md/LOOPS.md/CONTEXT.md directly
+- If copy-paste: Ask "Please paste STATE.md contents (or say 'new session')"
+
+**Step 2:** Resume or initialize
+- If artifacts exist: Load state and display "Session resumed: Phase [X], Loops [N]"
+- If new session: Create STATE.md, LOOPS.md, CONTEXT.md with defaults
+
+**Step 3:** Display initial state using sticky note format above
+
+## Key Behaviors
+
+**Loop Capture** (when questions arise):
+1. Identify open question during work
+2. Draft loop in XML format: `<loop id="LOOP-NNN" status="open">...</loop>`
+3. Propose to user → wait for approval
+4. Write to LOOPS.md after approval
+
+**Token Budget** (prevent context overload):
+- Start at 5000 tokens default
+- Track as files load
+- STOP at 50%+ to scope down
+- Document exclusions with rationale
+
+**Checkpoints** (progress visibility):
+- 📫 Loop captured (informational)
+- ✅ Task complete (informational)
+- 🛑 Blocking checkpoint (requires user action)
+
+**Systematic IDs** (global unique references):
+- Format: TYPE-NNN (e.g., LOOP-007, DECISION-008)
+- Never reuse IDs across sessions
+- Track all IDs in STATE.md
+
+## Full Protocol Documentation
+
+For complete details, see:
+- **BOOTLOADER_TEMPLATE.md** - Full initialization and protocol enforcement
+- **LOOPS_TEMPLATE.md** - Loop capture format and lifecycle
+- **CONTEXT_TEMPLATE.md** - Token budget management patterns
+- **STATE_TEMPLATE.md** - Session state structure
+- **SUMMARY_TEMPLATE.md** - Session export for GTD integration
+- **PROTOCOL_REFERENCE.md** - Quick reference for all patterns
+- **README.md** - Template navigation and workflow overview
+
+Location: `.planning/templates/` (or `.gsd-lite/templates/` in production)
+
+## What Makes This Different
+
+**User maintains ownership:** Agent proposes (loops, decisions, context exclusions) → user approves. You stay the author who understands "why."
+
+**File-based protocol:** Works via MCP (direct file access) OR copy-paste (manual transfer). Vendor-agnostic.
+
+**Educational inline:** Templates teach GSD mechanics through use, not lecture.
+
+**Session export:** Generate SUMMARY.md at end → export to GTD (TickTick/Things) → no 15-30 min reconstruction next session.
+
+---
+
+## Start Now
+
+**Your first response should:**
+1. Check for existing STATE.md (resume existing or create new session)
+2. Initialize artifacts if new session
+3. Display current state using sticky note format
+4. Follow protocol checklist every turn after
+
+**Protocol checklist (embedded in sticky note behavior):**
+- [ ] Update STATE.md after every turn
+- [ ] Capture loops when questions arise (propose → approval → write)
+- [ ] Track token budget in CONTEXT.md when loading files
+- [ ] Use checkpoints for progress visibility
+- [ ] Include sticky note when artifacts updated or actions changed
+
+---
+
+*Initialization prompt version: 1.0*
+*For full protocol: See `.planning/templates/BOOTLOADER_TEMPLATE.md`*
+*Part of: Phase 1 - Foundation & Templates*

--- a/.planning/templates/README.md
+++ b/.planning/templates/README.md
@@ -39,9 +39,21 @@ sequenceDiagram
 
 **Time to competence:** 30 minutes (read README → test session → export SUMMARY)
 
+### Fastest Start (One-Liner Trigger)
+
+**For immediate activation** → Copy `INIT_PROMPT.md` and paste into any LLM
+
+This concise initialization prompt (120 lines) activates gsd-lite protocol immediately:
+- Agent adopts sticky note format
+- Agent initializes session artifacts (STATE/LOOPS/CONTEXT)
+- Agent follows protocol from first response
+- Full documentation linked for reference
+
+**Use when:** You want instant activation without reading 300+ lines of documentation.
+
 ### Quick Start
 
-**Step 1: Start Session** → Copy `BOOTLOADER_TEMPLATE.md`
+**Step 1: Start Session** → Copy `INIT_PROMPT.md` (fastest) or `BOOTLOADER_TEMPLATE.md` (detailed)
 - Paste template into agent at session start
 - Agent initializes artifacts (STATE.md, LOOPS.md, CONTEXT.md)
 - Protocol enforcement activates (sticky notes, checkpoints, action menus)
@@ -59,7 +71,12 @@ sequenceDiagram
 
 ### What to Read First
 
-**Reading order for new users:**
+**Fastest path (start immediately):**
+1. **INIT_PROMPT.md** - Paste into LLM, activate gsd-lite mode instantly
+2. **Run a test session** - Experience protocol in action
+3. **BOOTLOADER_TEMPLATE.md** (optional) - Read for full protocol details
+
+**Learning path (understand first):**
 1. **This README** (you are here) - Get overview and workflow understanding
 2. **BOOTLOADER_TEMPLATE.md** - Learn how to initialize sessions and protocol
 3. **Run a test session** - Experience sticky notes, loop capture, token budget tracking
@@ -68,14 +85,35 @@ sequenceDiagram
 
 **Reading order for resuming work:**
 1. **Last session's SUMMARY.md** - "Next Session Prep" section tells you what to load
-2. **Paste BOOTLOADER** - Start new session with context from SUMMARY
+2. **Paste INIT_PROMPT** (fast) or **BOOTLOADER** (detailed) - Start new session with context from SUMMARY
 3. **Import loops from GTD** - Bring back clarified loops
 4. **Resume where you left off** - No 15-30 min reconstruction needed
 
 ## Template Index
 
+### INIT_PROMPT.md
+**Purpose**: Concise one-liner trigger for immediate gsd-lite activation
+
+**When to use**: When you want instant activation without reading full documentation
+
+**What it does**:
+- Activates gsd-lite protocol in ~120 lines (vs 356 in BOOTLOADER)
+- Embeds core behaviors (sticky notes, loop capture, artifact updates)
+- Provides initialization steps (check existing → create/resume session)
+- Links to full templates for detailed reference
+
+**Key sections**:
+- Core protocol summary (sticky note format)
+- Session artifacts overview (STATE/LOOPS/CONTEXT)
+- Initialization steps (3-step quick start)
+- Key behaviors (loop capture, token budget, checkpoints, systematic IDs)
+
+**Read this when**: You want to feed a concise prompt to an LLM and have it immediately adopt gsd-lite behavior. Full details available in BOOTLOADER_TEMPLATE.md.
+
+---
+
 ### BOOTLOADER_TEMPLATE.md
-**Purpose**: Session initialization and protocol enforcement
+**Purpose**: Session initialization and protocol enforcement (comprehensive version)
 
 **When to use**: Start of every new session
 
@@ -249,11 +287,13 @@ graph TD
 **Purpose**: Reference templates you copy/adapt for sessions
 
 **Files**:
-- `BOOTLOADER_TEMPLATE.md` - Session initialization
-- `LOOPS_TEMPLATE.md` - Loop capture format (pending)
-- `CONTEXT_TEMPLATE.md` - Token budget tracking (pending)
-- `STATE_TEMPLATE.md` - Working memory structure (pending)
+- `INIT_PROMPT.md` - Quick activation (one-liner trigger)
+- `BOOTLOADER_TEMPLATE.md` - Session initialization (comprehensive)
+- `LOOPS_TEMPLATE.md` - Loop capture format
+- `CONTEXT_TEMPLATE.md` - Token budget tracking
+- `STATE_TEMPLATE.md` - Working memory structure
 - `SUMMARY_TEMPLATE.md` - Session export format
+- `PROTOCOL_REFERENCE.md` - Quick reference for all patterns
 - `README.md` - This file
 
 **Do NOT edit**: Templates are reference materials. Editing them changes the pattern for future sessions.
@@ -292,8 +332,8 @@ graph TD
 **What Phase 1 delivers**:
 - File-based protocol that works across all agent types (MCP + copy-paste)
 - Heavily-commented templates that teach GSD mechanics through use
-- Core templates: BOOTLOADER, LOOPS, CONTEXT, STATE, SUMMARY
-- Protocol documentation and session workflow
+- Core templates: INIT_PROMPT (quick activation), BOOTLOADER (comprehensive), LOOPS, CONTEXT, STATE, SUMMARY
+- Protocol documentation (PROTOCOL_REFERENCE) and session workflow (README)
 
 **What's NOT in Phase 1** (coming later):
 - **Phase 2**: Session handoff system (pause/resume across days, continuity between sessions)
@@ -325,7 +365,14 @@ graph TD
 
 ## What to Read First
 
-**If you're new to this system:**
+**If you want to start immediately (fastest path):**
+1. Copy INIT_PROMPT.md → paste into any LLM
+2. Agent activates gsd-lite mode and starts session
+3. Experience sticky notes, loop capture, token budget tracking
+4. Generate a SUMMARY at end of test session
+5. Read BOOTLOADER_TEMPLATE.md for full protocol details (optional)
+
+**If you want to understand first (learning path):**
 1. Read this README (you are here)
 2. Read BOOTLOADER_TEMPLATE.md (understand session initialization and protocol)
 3. Start a test session with BOOTLOADER
@@ -503,4 +550,4 @@ As you use these templates, you'll discover patterns worth capturing:
 
 **Last updated**: 2026-01-21
 **Phase**: 1 - Foundation & Templates
-**Status**: BOOTLOADER and SUMMARY complete, core templates pending
+**Status**: All templates complete (INIT_PROMPT, BOOTLOADER, LOOPS, CONTEXT, STATE, SUMMARY, PROTOCOL_REFERENCE, README)


### PR DESCRIPTION
Add INIT_PROMPT.md (~120 lines) as a one-liner activation command
for gsd-lite protocol. This solves the issue where existing templates
(BOOTLOADER 356 lines, README 506 lines) were too documentation-heavy
to serve as quick trigger commands for LLMs.

What INIT_PROMPT provides:
- Immediate activation of gsd-lite protocol
- Core behaviors embedded (sticky notes, loop capture, artifacts)
- Initialization steps (check existing → create/resume)
- Links to full documentation for reference

Updated README.md to:
- Add "Fastest Start" section featuring INIT_PROMPT
- Update Template Index with INIT_PROMPT entry
- Add fastest/learning paths in "What to Read First"
- Update file listings and phase context status

This allows users to feed a concise prompt to any LLM (Claude,
ChatGPT, Gemini) and have it immediately pick up gsd-lite behavior
without reading 300+ lines of documentation first.