### PR TITLE
feat: add echo-back onboarding protocol to progress workflow

### DIFF
--- a/src/gsd_lite/template/workflows/progress.md
+++ b/src/gsd_lite/template/workflows/progress.md
@@ -99,7 +99,7 @@ Extract and present:
 
 **Why:** ARCHITECTURE.md grounds the agent in the codebase reality. Understanding the technical landscape prevents misguided suggestions.
 
-**If ARCHITECTURE.md missing:** Note it and suggest running map-codebase workflow if working with existing code.
+**If ARCHITECTURE.md missing:** Refer to the "Missing High-Level Context" special case handling below.
 
 ### Step 5: Read Current Understanding (Ground-Level State)
 


### PR DESCRIPTION
Progress workflow now requires agents to demonstrate understanding before
continuing work. This addresses the "forwarder problem" where agents execute
without context.

Changes:
- Add Steps 3-4: Echo back PROJECT.md vision and ARCHITECTURE.md overview
- Update status report to show high-level → ground-level context flow
- Add "Missing High-Level Context" special case for transparency
- Update sticky note to confirm "ONBOARDED" with understanding summary
- Add anti-patterns for silent onboarding and context assumptions

Philosophy: Fresh sessions = agents must prove they understand the project's
"why" and the codebase's "how" before diving into tactical work.

https://claude.ai/code/session_016WpPcgxmhJKujmvxSNDhw6